### PR TITLE
Implement NNPOps Optimised ANI

### DIFF
--- a/openmmml/models/anipotential.py
+++ b/openmmml/models/anipotential.py
@@ -31,6 +31,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from openmmml.mlpotential import MLPotential, MLPotentialImpl, MLPotentialImplFactory
 import openmm
+from NNPOps import OptimizedTorchANI
 from typing import Iterable, Optional
 
 class ANIPotentialImplFactory(MLPotentialImplFactory):
@@ -83,6 +84,9 @@ class ANIPotentialImpl(MLPotentialImpl):
             includedAtoms = [includedAtoms[i] for i in atoms]
         elements = [atom.element.symbol for atom in includedAtoms]
         species = model.species_to_tensor(elements).unsqueeze(0)
+
+        device = torch.device('cuda')
+        model = OptimizedTorchANI(model, species).to(device)
 
         class ANIForce(torch.nn.Module):
 


### PR DESCRIPTION
These changes simplify the use of NNPOps OptimisedTorchANI in OpenMM simulations, allowing ANI2x to be used with ~6x speedup on my machine. It also allows periodic boundary conditions again for CUDA (see https://github.com/aiqm/torchani/issues/607#issuecomment-1023628057)

- Faster ANI for small, unsolvated systems
- Allows large solvated systems to be run using mixed ANI/AMBER

Thanks to @jchodera for his example code https://github.com/openmm/openmm-torch/issues/59#issuecomment-1028042839
Addresses https://github.com/openmm/openmm-ml/issues/14

Demonstration
https://github.com/meyresearch/ANI-Peptides/blob/main/demos/ANI_minimal.ipynb

Important to note that this PR lacks an option to choose between classic TorchANI and OptimisedTorchANI, instead enforcing NNPops as the only method. I'd be happy to implement a way to choose between the two, but I'm not sure how this would best be implemented to fit this library's structure?

eg.

```py
openmmml.MLPotential('ani2x_optimised')
```
or perhaps
```py
openmmml.MLPotential('ani2x', optimised=True)
```