### PR TITLE
use pbc for internalNonbonded force

### DIFF
--- a/openmmml/mlpotential.py
+++ b/openmmml/mlpotential.py
@@ -299,6 +299,8 @@ class MLPotential(object):
                     internalNonbonded.addPerBondParameter('chargeProd')
                     internalNonbonded.addPerBondParameter('sigma')
                     internalNonbonded.addPerBondParameter('epsilon')
+                    if force.usesPeriodicBoundaryConditions():
+                        internalNonbonded.setUsesPeriodicBoundaryConditions(True)
                     numParticles = system.getNumParticles()
                     atomCharge = [0]*numParticles
                     atomSigma = [0]*numParticles


### PR DESCRIPTION
As suggested here https://github.com/openmm/openmm-ml/issues/52#issuecomment-1478632563, I added `setUsesPeriodicBoundaryConditions(True)` for the internalNonbonded Force in the `customCV` force to account for PBC if needed.