### PR TITLE
Fix the workflow for rendering the website

### DIFF
--- a/.github/workflows/docs_website.yml
+++ b/.github/workflows/docs_website.yml
@@ -20,18 +20,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{hashFiles('environment.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         name: Install dependencies
         with:
           environment-file: doc/environment.yml
           auto-activate-base: false
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           use-mamba: true
 
       - name: Describe environment

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -4,12 +4,13 @@ channels:
 dependencies:
   - python
   - pip
-  - sphinx
+  - setuptools
   - openmm
+  - sphinx
   - pydata-sphinx-theme
   - pip:
     - m2r2
     - GitPython
-
+    - docutils>=0.18.1,<0.21
 
 


### PR DESCRIPTION
This PR fixes the workflow for rendering the website. The versions of some actions had to be updated; Mambaforge is now deprecated (Miniforge must be used); setuptools must be explicitly installed and the version of docutils pinned.