### PR TITLE
Fix issue #100

### DIFF
--- a/openmmml/mlpotential.py
+++ b/openmmml/mlpotential.py
@@ -274,7 +274,7 @@ class MLPotential(object):
                     for j in range(i):
                         a2 = atomList[j]
                         if (a1, a2) not in existing and (a2, a1) not in existing:
-                            force.addExclusion(a1, a2, True)
+                            force.addExclusion(a1, a2)
 
         # Add the ML potential.
 


### PR DESCRIPTION
This PR closes #100 by fixing the call to `CustomNonbondedForce.addExclusion()` when creating a mixed system.