### PR TITLE
Better error message if torchani is not installed

### DIFF
--- a/openmmml/models/anipotential.py
+++ b/openmmml/models/anipotential.py
@@ -68,7 +68,10 @@ class ANIPotentialImpl(MLPotentialImpl):
                   **args):
         # Create the TorchANI model.
 
-        import torchani
+        try:
+            import torchani
+        except ImportError as e:
+            raise ImportError(f"Failed to import torchani with error: {e}. Make sure torchani is installed.")
         import torch
         import openmmtorch
 


### PR DESCRIPTION
This provides a better error message if the user tries to create an ANI potential, and torchani is not installed.