### PR TITLE
Default to TorchANI instead of NNPOps

### DIFF
--- a/openmmml/models/anipotential.py
+++ b/openmmml/models/anipotential.py
@@ -63,7 +63,7 @@ class ANIPotentialImpl(MLPotentialImpl):
                   system: openmm.System,
                   atoms: Optional[Iterable[int]],
                   forceGroup: int,
-                  implementation: str = 'nnpops',
+                  implementation: str = 'torchani',
                   modelIndex: Optional[int] = None,
                   **args):
         # Create the TorchANI model.


### PR DESCRIPTION
ANIPotentialImpl lets you select whether to use the implementation from TorchANI or NNPOps.  This changes the default to TorchANI.  The reasons include

- It eliminates a dependency by default, making installation easier.
- NNPOps is currently incompatible with recent versions of TorchANI.  Hopefully we'll get that fixed soon, but for the moment the version conflicts make it even harder to get a working installation.
- NNPOps isn't always a better choice.  It's faster for small molecules, but it uses a lot more memory, and it's slower for large molecules.
- Long term, we don't want to have to keep maintaining the NNPOps code that's specific to TorchANI.