### PR TITLE
Support ASE Calculators

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -205,7 +205,6 @@ Pretrained and your own local models are supported.
 | `aceff-2.0` | Pretrained [AceFF-2.0](https://huggingface.co/Acellera/AceFF-2.0) [TensorNet2](https://arxiv.org/abs/2601.00581) model. |
 | `torchmdnet` |  Custom TorchMD-Net models specified with the `modelPath` argument. |
 
-
 When creating TorchMD-Net models, the following keyword arguments to the `MLPotential` constructor are supported.
 
 | Argument | Description |
@@ -216,17 +215,55 @@ When creating TorchMD-Net models, the following keyword arguments to the `MLPote
 
 When using TorchMD-Net models, the following extra keyword arguments to `createSystem()` and `createMixedSystem()` are supported.
 
-| Argument       | Description |
+| Argument | Description |
 | --- | --- |
-| `charge`       | The total charge of the system.  If omitted, it is assumed to be 0. |
+| `charge` | The total charge of the system.  If omitted, it is assumed to be 0. |
 | `cudaGraphs` | Flag to enable CUDA graphs. If omitted it is set to `True` if the TorchMD-Net model is TensorNet, and `False` otherwise. |
 | `remove_ref_energy` | Argument passed to the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). Default is `True`.  |
 | `max_num_neighbors` | Argument passed to the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). Default is the minimum of 64 or the number of atoms in the molecule.
 | `batch` | Argument passed to the forward call of the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). With this argument you can denote different atoms to be in different batches. The format should be a 1d list containing the batch index of each atom. e.g. for two molecules each with three atoms to be treated as seperate batches you would pass `batch = [0, 0, 0, 1, 1, 1]`.
 
+### ASE
 
+OpenMM-ML can use an arbitrary [ASE](https://ase-lib.org/) Calculator to perform calculations.  This allows it to use
+any model or code for which a Calculator is available, including a wide variety of MLIPs and quantum chemistry programs.
+Simply pass the [Calculator](https://ase-lib.org/ase/calculators/calculators.html) to `createSystem()`:
 
+```python
+potential = MLPotential('ase')
+system = potential.createSystem(topology, calculator=calculator)
+```
 
+An ASE [Atoms](https://ase-lib.org/ase/atoms.html) object is created automatically based on the OpenMM Topology.  You
+can optionally provide values to add to its `info` dict.  Some Calculators use this as a mechanism to specify parameters
+like total charge and spin multiplicity:
+
+```python
+system = potential.createSystem(topology, calculator=calculator, info={'charge':2})
+```
+
+In cases where you need more direct control, you can instead create an Atoms object yourself and provide it directly:
+
+```python
+system = potential.createSystem(topology, aseAtoms=atoms)
+```
+
+In this case, the Atoms should already be fully configured, including having a Calculator set.  It is up to you to make
+sure the Atoms and Topology are fully consistent with each other.
+
+The following model names are supported.
+
+| Name | Model |
+| --- | --- |
+| `ase` | Custom models specified with either the `calculator` or `aseAtoms` argument |
+
+When using ASE models, the following extra keyword arguments to `createSystem()` and `createMixedSystem()` are supported.
+
+| Argument | Description |
+| --- | --- |
+| `calculator` | The Calculator to use for computations.  An Atoms object is created automatically. |
+| `aseAtoms` | An Atoms object to use for computations. |
+| `info` | Values that should be added to the `info` dict of the Atoms object. |
 
 ### Other Packages
 

--- a/openmmml/models/asepotential.py
+++ b/openmmml/models/asepotential.py
@@ -1,0 +1,134 @@
+"""
+asepotential.py: Potential functions implemented with an ASE calculator
+
+This is part of the OpenMM molecular simulation toolkit originating from
+Simbios, the NIH National Center for Physics-Based Simulation of
+Biological Structures at Stanford, funded under the NIH Roadmap for
+Medical Research, grant U54 GM072970. See https://simtk.org.
+
+Portions copyright (c) 2026 Stanford University and the Authors.
+Authors: Peter Eastman
+Contributors:
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from openmmml.mlpotential import MLPotential, MLPotentialImpl, MLPotentialImplFactory
+import openmm
+from openmm import unit
+from typing import Iterable, Optional
+from functools import partial
+
+class ASEPotentialImplFactory(MLPotentialImplFactory):
+    """This is the factory that creates ASEPotentialImpl objects."""
+
+    def createImpl(self, name: str, **args) -> MLPotentialImpl:
+        return ASEPotentialImpl(name)
+
+
+class ASEPotentialImpl(MLPotentialImpl):
+    """This MLPotentialImpl implements potentials using an ASE calculator.
+
+    It can be used in two ways.  One option is to provide an ASE Atoms object that has already been configured with the
+    correct calculator and all other settings.
+
+    >>> potential = MLPotential('ase')
+    >>> system = potential.createSystem(topology, aseAtoms=atoms)
+
+    When used this way, you must make sure the Atoms object describes exactly the same atoms in the same order as the
+    OpenMM Topology.  If it does not, you will get incorrect results.
+
+    Alternatively you can provide a calculator.  In this case, `createSystem()` automatically creates an Atoms object
+    based on the Topology and assigns the calculator to it.
+
+    >>> system = potential.createSystem(topology, calculator=calculator)
+
+    When used this way, you can optionally include an `info` argument with properties that should be added to the Atoms
+    object's info dict.
+
+    >>> system = potential.createSystem(topology, calculator=calculator, info={'charge':2})
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def addForces(self,
+                  topology: openmm.app.Topology,
+                  system: openmm.System,
+                  atoms: Optional[Iterable[int]],
+                  forceGroup: int,
+                  **args):
+        try:
+            import ase
+        except ImportError as e:
+            raise ImportError("Failed to import ASE.  Install it as described at https://ase-lib.org/install.html.")
+        if any(atom.element is None for atom in topology.atoms()):
+            raise ValueError('All atoms in the Topology must have elements defined.')
+        includedAtoms = list(topology.atoms())
+        if atoms is None:
+            indices = None
+        else:
+            includedAtoms = [includedAtoms[i] for i in atoms]
+            indices = sorted(atoms)
+        if 'aseAtoms' in args:
+            # The user provided an Atoms object.
+
+            aseAtoms = args['aseAtoms']
+            if len(aseAtoms.numbers) != len(includedAtoms):
+                raise ValueError('The ASE Atoms object contains the wrong number of atoms.')
+            if any(n != atom.element.atomic_number for n, atom in zip(aseAtoms.numbers, includedAtoms)):
+                raise ValueError('The elements specified in the ASE Atoms and OpenMM Topology do not agree.')
+        else:
+            # Create an Atoms object.
+
+            if 'calculator' not in args:
+                raise ValueError('Either an Atoms or a Calculator must be provided')
+            numbers = [atom.element.atomic_number for atom in includedAtoms]
+            pbc = (topology.getPeriodicBoxVectors() is not None)
+            aseAtoms = ase.Atoms(numbers=numbers, pbc=pbc, calculator=args['calculator'])
+        if 'info' in args:
+            for key, value in args['info'].items():
+                aseAtoms.info[key] = value
+
+        # Create the PythonForce and add it to the System.
+
+        compute = partial(_computeASE, atoms=aseAtoms, indices=indices)
+        force = openmm.PythonForce(compute)
+        force.setForceGroup(forceGroup)
+        force.setUsesPeriodicBoundaryConditions(any(aseAtoms.get_pbc()))
+        system.addForce(force)
+
+
+def _computeASE(state, atoms, indices):
+    import ase.units
+    import numpy as np
+    positions = state.getPositions(asNumpy=True).value_in_unit(unit.angstrom)
+    numAtoms = positions.shape[0]
+    if indices is not None:
+        positions = positions[indices]
+    atoms.set_positions(positions)
+    if any(atoms.get_pbc()):
+        atoms.set_cell(state.getPeriodicBoxVectors(asNumpy=True).value_in_unit(unit.angstrom))
+    energy = atoms.get_potential_energy(apply_constraint=False)
+    forces = atoms.get_forces(apply_constraint=False)
+    if indices is not None:
+        f = np.zeros((numAtoms, 3), dtype=np.float32)
+        f[indices] = forces
+        forces = f
+    return energy/(ase.units.kJ/ase.units.mol), forces/(10*ase.units.kJ/ase.units.mol)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
             'aimnet2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'ani1ccx = openmmml.models.anipotential:ANIPotentialImplFactory',
             'ani2x = openmmml.models.anipotential:ANIPotentialImplFactory',
+            'ase = openmmml.models.asepotential:ASEPotentialImplFactory',
             'mace = openmmml.models.macepotential:MACEPotentialImplFactory',
             'mace-off23-small = openmmml.models.macepotential:MACEPotentialImplFactory',
             'mace-off23-medium = openmmml.models.macepotential:MACEPotentialImplFactory',

--- a/test/TestASEPotential.py
+++ b/test/TestASEPotential.py
@@ -1,0 +1,85 @@
+import os
+
+import numpy as np
+import openmm as mm
+import openmm.app as app
+import openmm.unit as unit
+import pytest
+
+from openmmml import MLPotential
+
+mace = pytest.importorskip("mace", reason="MACE is not installed")
+ase = pytest.importorskip("ase", reason="ASE is not installed")
+platform_ints = range(mm.Platform.getNumPlatforms())
+# Get the path to the test data
+test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+
+@pytest.mark.parametrize("platform_int", list(platform_ints))
+class TestASEPotential:
+    def testCalculator(self, platform_int):
+        from mace.calculators.foundations_models import mace_off
+        pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
+        potential = MLPotential('ase')
+        calculator = mace_off('small', default_dtype='float32')
+        system = potential.createSystem(pdb.topology, calculator=calculator)
+        platform = mm.Platform.getPlatform(platform_int)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
+        context.setPositions(pdb.getPositions(asNumpy=True))
+        energyML = context.getState(energy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        assert np.isclose(-713468.6327560507, energyML, rtol=1e-6)
+
+    def testAtoms(self, platform_int):
+        from mace.calculators.foundations_models import mace_off
+        import ase.io
+        path = os.path.join(test_data_dir, "toluene", "toluene.pdb")
+        pdb = app.PDBFile(path)
+        atoms = ase.io.read(path)
+        atoms.calc = mace_off('small', default_dtype='float32')
+        potential = MLPotential('ase')
+        system = potential.createSystem(pdb.topology, aseAtoms=atoms)
+        platform = mm.Platform.getPlatform(platform_int)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
+        context.setPositions(pdb.getPositions(asNumpy=True))
+        energyML = context.getState(energy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        assert np.isclose(-713468.6327560507, energyML, rtol=1e-6)
+
+    def testPeriodicSystem(self, platform_int):
+        from mace.calculators.foundations_models import mace_off
+        pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))
+        potential = MLPotential('ase')
+        calculator = mace_off('small', default_dtype='float32')
+        system = potential.createSystem(pdb.topology, calculator=calculator)
+        platform = mm.Platform.getPlatform(platform_int)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
+        positionsOriginal = pdb.getPositions(asNumpy=True)
+        energyRef = -151723354.26015 # Calculated with MACECalculator
+        for i in range(3):
+            positions = positionsOriginal + i * 0.9 * unit.nanometers # translate molecule to test PBC
+            context.setPositions(positions)
+            energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+            assert np.isclose(energyRef, energyML, rtol=1e-5)
+
+    def testCreateMixedSystem(self, platform_int):
+        from mace.calculators.foundations_models import mace_off
+        prmtop = app.AmberPrmtopFile(os.path.join(test_data_dir, "toluene", "toluene-explicit.prm7"))
+        inpcrd = app.AmberInpcrdFile(os.path.join(test_data_dir, "toluene", "toluene-explicit.rst7"))
+        mlAtoms = list(range(15))
+        mmSystem = prmtop.createSystem(nonbondedMethod=app.PME)
+        potential = MLPotential('ase')
+        calculator = mace_off('small', default_dtype='float32')
+        mixedSystem = potential.createMixedSystem(prmtop.topology, mmSystem, mlAtoms, interpolate=False, calculator=calculator)
+        interpSystem = potential.createMixedSystem(prmtop.topology, mmSystem, mlAtoms, interpolate=True, calculator=calculator)
+        platform = mm.Platform.getPlatform(platform_int)
+        mmContext = mm.Context(mmSystem, mm.VerletIntegrator(0.001), platform)
+        mixedContext = mm.Context(mixedSystem, mm.VerletIntegrator(0.001), platform)
+        interpContext = mm.Context(interpSystem, mm.VerletIntegrator(0.001), platform)
+        mmContext.setPositions(inpcrd.positions)
+        mixedContext.setPositions(inpcrd.positions)
+        interpContext.setPositions(inpcrd.positions)
+        mmEnergy = mmContext.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        mixedEnergy = mixedContext.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        interpEnergy1 = interpContext.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        interpContext.setParameter('lambda_interpolate', 0)
+        interpEnergy2 = interpContext.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        assert np.isclose(mixedEnergy, interpEnergy1, rtol=1e-5)
+        assert np.isclose(mmEnergy, interpEnergy2, rtol=1e-5)


### PR DESCRIPTION
This allows OpenMM-ML to use an arbitrary ASE Calculator for a simulation.  This gives us access to a very large set of ML potentials, and also lots of quantum chemistry packages.