### PR TITLE
Use numpy array for indices

### DIFF
--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -34,6 +34,7 @@ import openmm
 from openmm import unit
 from typing import Iterable, Optional
 from functools import partial
+import numpy as np
 
 class AIMNet2PotentialImplFactory(MLPotentialImplFactory):
     """This is the factory that creates AIMNet2PotentialImpl objects."""
@@ -78,7 +79,7 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
             indices = None
         else:
             includedAtoms = [includedAtoms[i] for i in atoms]
-            indices = torch.tensor(sorted(atoms), dtype=torch.int64, device=device)
+            indices = np.array(sorted(atoms))
         numbers = torch.tensor([[atom.element.atomic_number for atom in includedAtoms]], device=device)
         charge = torch.tensor([args.get('charge', 0)], dtype=torch.float32, device=device)
         multiplicity = torch.tensor([args.get('multiplicity', 1)], dtype=torch.float32, device=device)
@@ -95,7 +96,6 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
 
 def _computeAIMNet2(state, model, numbers, charge, multiplicity, indices, periodic):
     import torch
-    import numpy as np
     positions = torch.tensor(state.getPositions(asNumpy=True).value_in_unit(unit.angstrom), dtype=torch.float32, device=numbers.device)
     numAtoms = positions.shape[0]
     if indices is not None:

--- a/openmmml/models/asepotential.py
+++ b/openmmml/models/asepotential.py
@@ -34,6 +34,7 @@ import openmm
 from openmm import unit
 from typing import Iterable, Optional
 from functools import partial
+import numpy as np
 
 class ASEPotentialImplFactory(MLPotentialImplFactory):
     """This is the factory that creates ASEPotentialImpl objects."""
@@ -85,7 +86,7 @@ class ASEPotentialImpl(MLPotentialImpl):
             indices = None
         else:
             includedAtoms = [includedAtoms[i] for i in atoms]
-            indices = sorted(atoms)
+            indices = np.array(sorted(atoms))
         if 'aseAtoms' in args:
             # The user provided an Atoms object.
 
@@ -117,7 +118,6 @@ class ASEPotentialImpl(MLPotentialImpl):
 
 def _computeASE(state, atoms, indices):
     import ase.units
-    import numpy as np
     positions = state.getPositions(asNumpy=True).value_in_unit(unit.angstrom)
     numAtoms = positions.shape[0]
     if indices is not None:

--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -33,6 +33,7 @@ from openmm import unit
 from openmmml.mlpotential import MLPotential, MLPotentialImpl, MLPotentialImplFactory
 from typing import Iterable, Optional
 from functools import partial
+import numpy as np
 
 
 class MACEPotentialImplFactory(MLPotentialImplFactory):
@@ -206,7 +207,7 @@ class MACEPotentialImpl(MLPotentialImpl):
         if atoms is None:
             indices = None
         else:
-            indices = torch.tensor(sorted(atoms), dtype=torch.int64)
+            indices = np.array(sorted(atoms))
         periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
 
         # Create the PythonForce and add it to the System.
@@ -230,7 +231,6 @@ class MACEPotentialImpl(MLPotentialImpl):
 
 def _computeMACE(state, model, ptr, node_attrs, batch, pbc, returnEnergyType, charge, multiplicity, indices, periodic):
     import torch
-    import numpy as np
     from mace.data.neighborhood import get_neighborhood
     energyScale = 96.4853
     lengthScale = 10.0

--- a/openmmml/models/nequippotential.py
+++ b/openmmml/models/nequippotential.py
@@ -34,6 +34,7 @@ import openmm
 from openmm import unit
 from openmmml.mlpotential import MLPotentialImpl, MLPotentialImplFactory
 from functools import partial
+import numpy as np
 
 
 class NequIPPotentialImplFactory(MLPotentialImplFactory):
@@ -201,7 +202,7 @@ class NequIPPotentialImpl(MLPotentialImpl):
         if atoms is None:
             indices = None
         else:
-            indices = torch.tensor(sorted(atoms), dtype=torch.int64, requires_grad=False, device=device)
+            indices = np.array(sorted(atoms))
         atomTypes = torch.tensor(atomTypes, dtype=torch.long, requires_grad=False, device=device)
         periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
         pbc = torch.tensor([periodic, periodic, periodic], dtype=torch.bool, requires_grad=False, device=device)
@@ -225,7 +226,6 @@ class NequIPPotentialImpl(MLPotentialImpl):
 
 def _computeNequIP(state, model, atomTypes, cutoff, lengthScale, energyScale, indices, periodic, pbc):
     import torch
-    import numpy as np
     from nequip.data._nl import compute_neighborlist_
     positions = state.getPositions(asNumpy=True).value_in_unit(unit.nanometer)/lengthScale
     numAtoms = positions.shape[0]

--- a/openmmml/models/torchmdnetpotential.py
+++ b/openmmml/models/torchmdnetpotential.py
@@ -32,6 +32,7 @@ import openmm
 from openmm import unit
 from openmmml.mlpotential import MLPotentialImpl, MLPotentialImplFactory
 from typing import Iterable, Optional
+import numpy as np
 
 class TorchMDNetPotentialImplFactory(MLPotentialImplFactory):
     """This is the factory that creates TorchMDNetPotentialImpl objects."""
@@ -180,7 +181,7 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
         if atoms is None:
             indices = None
         else:
-            indices = torch.tensor(sorted(atoms), dtype=torch.int64, requires_grad=False)
+            indices = np.array(sorted(atoms))
         periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
 
         # Create the PythonForce and add it to the System.
@@ -213,7 +214,6 @@ class _ComputeTorchMDNet(object):
 
     def __call__(self, state):
         import torch
-        import numpy as np
         positions = state.getPositions(asNumpy=True).value_in_unit(unit.nanometer)
         numAtoms = positions.shape[0]
         positions = torch.tensor(positions, dtype=torch.float32, device=self.numbers.device)


### PR DESCRIPTION
The indices array was being represented as a PyTorch tensor, even though it was only ever used to index into NumPy arrays.  This caused errors when running on CUDA, and in any case required extra conversions between tensors and arrays.