### PR TITLE
fix for #128

### DIFF
--- a/openmmml/models/torchmdnetpotential.py
+++ b/openmmml/models/torchmdnetpotential.py
@@ -227,25 +227,10 @@ class _ComputeTorchMDNet(object):
         if self.compiled_model is None:
             # The model can't be compiled until after it has been invoked once.
 
-<<<<<<< HEAD
             energy = self.model(z=self.numbers, pos=positions/self.lengthScale, batch=self.batch, q=self.charge, box=cell)[0]*self.energyScale
             self.compiled_model = torch.compile(self.model, backend="inductor", dynamic=False, fullgraph=True, mode="default")
         else:
             energy = self.compiled_model(z=self.numbers, pos=positions/self.lengthScale, batch=self.batch, q=self.charge, box=cell)[0]*self.energyScale
-=======
-        if self.compiled_model is None:
-            # Reset dynamo caches to avoid conflicts with compiled state
-            # from a previous molecule's model.
-            torch._dynamo.reset()
-            # Warmup pass to set dim_size before compilation.
-            # torch.compile doesn't support .item() calls used internally.
-            self.model.to(self.numbers.device)
-            with torch.no_grad():
-                self.model(z=self.numbers, pos=positions/self.lengthScale, batch=self.batch, q=self.charge, box=cell)
-            self.compiled_model = torch.compile(self.model, backend="inductor", dynamic=False, fullgraph=True, mode="default")
-
-        energy = self.compiled_model(z=self.numbers, pos=positions/self.lengthScale, batch=self.batch, q=self.charge, box=cell)[0]*self.energyScale
->>>>>>> ac9b17d4615e5aad5ba94b4b8d284005782d2c7b
         energy.backward()
         forces = (-positions.grad).detach().cpu().numpy()
         if self.indices is not None:


### PR DESCRIPTION
I am not too familiar with torch, so I tried some fixes with the help of Claude. Please take a look @sef43, @peastman if these changes make sense. This works now on the failure case I mentioned in #128 .

Three changes from the original code:

1. torch._dynamo.reset() before compilation — Clears stale dynamo bytecode caches from any previous molecule's compilation.

2.    No-grad warmup pass before torch.compile — Runs the model once with torch.no_grad() to set internal dim_size values. torch.compile doesn't support the .item() calls used internally by torchmdnet on the first invocation, so this must happen on the uncompiled model.

3.    mode="default" instead of mode="reduce-overhead" — The reduce-overhead mode records CUDA graphs that are shape-locked per process and cannot be reliably reset when a second molecule with different atom count is compiled. mode="default" still provides kernel fusion via inductor JIT but avoids CUDA graphs entirely.
