### PR TITLE
torchmdnet coulomb_cutoff only if periodic

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -234,13 +234,8 @@ When using TorchMD-Net models, the following extra keyword arguments to `createS
 #### Coulomb cutoff behaviour
 
 The Coulomb cutoff in TorchMD-Net uses a reaction-field approximation.  Applying it to a non-periodic
-system introduces errors, so by default the cutoff is only used when the ML potential is evaluated
-under periodic boundary conditions:
-
-* **No PBCs on the topology/system:** the cutoff is disabled (in-vacuum evaluation).
-* **PBCs + `createMixedSystem()`:** mechanical embedding is assumed, the ML subset is treated as an
-  isolated cluster, and the cutoff is disabled.
-* **PBCs + `createSystem()` (full ML system):** the cutoff is applied.
+system introduces errors, so by default the cutoff is only used when the system uses periodic
+boundary conditions.
 
 You can override this with the `useCoulombCutoff` argument if you know which behaviour you want:
 

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -225,10 +225,28 @@ When using TorchMD-Net models, the following extra keyword arguments to `createS
 | Argument | Description |
 | --- | --- |
 | `charge` | The total charge of the system.  If omitted, it is assumed to be 0. |
-| `coulomb_cutoff` | The cutoff distance to apply to Coulomb interactions, in nanometers.  If omitted, it defaults to 1.2 nm.  For models without an explicit Coulomb term, this is ignored. |
+| `coulomb_cutoff` | The cutoff distance to apply to Coulomb interactions, in nanometers.  If omitted, it defaults to 1.2 nm.  For models without an explicit Coulomb term, this is ignored.  Whether the cutoff is actually applied depends on `useCoulombCutoff` (see below). |
+| `useCoulombCutoff` | Override whether the Coulomb cutoff is applied.  If omitted, the default is determined automatically (see *Coulomb cutoff behavior* below).  Pass `True` to always apply the cutoff or `False` to disable it. |
 | `remove_ref_energy` | Argument passed to the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). Default is `True`.  |
 | `max_num_neighbors` | Argument passed to the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). Default is the minimum of 64 or the number of atoms in the molecule.
 | `batch` | Argument passed to the forward call of the TorchMD-Net model, please see [here](https://torchmd-net.readthedocs.io/en/latest/). With this argument you can denote different atoms to be in different batches. The format should be a 1d list containing the batch index of each atom. e.g. for two molecules each with three atoms to be treated as seperate batches you would pass `batch = [0, 0, 0, 1, 1, 1]`.
+
+#### Coulomb cutoff behaviour
+
+The Coulomb cutoff in TorchMD-Net uses a reaction-field approximation.  Applying it to a non-periodic
+system introduces errors, so by default the cutoff is only used when the ML potential is evaluated
+under periodic boundary conditions:
+
+* **No PBCs on the topology/system:** the cutoff is disabled (in-vacuum evaluation).
+* **PBCs + `createMixedSystem()`:** mechanical embedding is assumed, the ML subset is treated as an
+  isolated cluster, and the cutoff is disabled.
+* **PBCs + `createSystem()` (full ML system):** the cutoff is applied.
+
+You can override this with the `useCoulombCutoff` argument if you know which behaviour you want:
+
+```python
+system = potential.createSystem(topology, useCoulombCutoff=False)
+```
 
 ### FeNNix
 

--- a/openmmml/models/torchmdnetpotential.py
+++ b/openmmml/models/torchmdnetpotential.py
@@ -162,12 +162,13 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
                 filename=filename,
             )
 
+        periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()  
         model = load_model(
             model_file_path,
             derivative=False,
             remove_ref_energy = args.get('remove_ref_energy', True),
             max_num_neighbors = min(args.get('max_num_neighbors', 64), numbers.shape[0]),
-            coulomb_cutoff = cutoff,
+            coulomb_cutoff = cutoff if periodic else None,
             static_shapes = True,
             check_errors = False
         ).to(device)
@@ -182,7 +183,6 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
             indices = None
         else:
             indices = np.array(atoms)
-        periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
 
         # Create the PythonForce and add it to the System.
 
@@ -227,7 +227,6 @@ class _ComputeTorchMDNet(object):
             cell = None
         if self.compiled_model is None:
             # The model can't be compiled until after it has been invoked once.
-
             energy = self.model(z=self.numbers, pos=positions/self.lengthScale, batch=self.batch, q=self.charge, box=cell)[0]*self.energyScale
             self.compiled_model = torch.compile(self.model, backend="inductor", dynamic=False, fullgraph=True, mode="reduce-overhead")
         else:

--- a/openmmml/models/torchmdnetpotential.py
+++ b/openmmml/models/torchmdnetpotential.py
@@ -84,13 +84,8 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
     Coulomb cutoff behavior
     ------------------------
     The Coulomb cutoff in TorchMD-Net uses a reaction-field approximation. Applying it to a
-    non-periodic system introduces errors, so by default the cutoff is only used when the ML
-    potential is evaluated under periodic boundary conditions:
-
-    * No PBCs on the topology/system: the cutoff is disabled (in-vacuum evaluation).
-    * PBCs and ``createMixedSystem`` is being used: mechanical embedding is assumed, the
-      ML subset is treated as an isolated cluster, and the cutoff is disabled.
-    * PBCs and ``createSystem`` (full ML system): the cutoff is applied.
+    non-periodic system introduces errors, so by default the cutoff is only used when the
+    system uses periodic boundary conditions.
 
     You can override this with the ``useCoulombCutoff`` argument if you know which behavior
     you want, for example:
@@ -178,13 +173,7 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
                 filename=filename,
             )
 
-        # In createMixedSystem (atoms is not None) we assume mechanical embedding, so the ML
-        # subset is treated as an isolated cluster regardless of the surrounding system's PBCs.
-        system_periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
-        mixed_system = atoms is not None
-        periodic = system_periodic and not mixed_system
-        # Allow the caller to override whether the Coulomb cutoff is applied. By default it is
-        # only applied when the ML potential is being evaluated under PBCs (i.e. periodic=True).
+        periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
         use_coulomb_cutoff = args.get('useCoulombCutoff', periodic)
         model = load_model(
             model_file_path,

--- a/openmmml/models/torchmdnetpotential.py
+++ b/openmmml/models/torchmdnetpotential.py
@@ -81,6 +81,22 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
 
     >>> potential = MLPotential('aceff-1.0')
 
+    Coulomb cutoff behavior
+    ------------------------
+    The Coulomb cutoff in TorchMD-Net uses a reaction-field approximation. Applying it to a
+    non-periodic system introduces errors, so by default the cutoff is only used when the ML
+    potential is evaluated under periodic boundary conditions:
+
+    * No PBCs on the topology/system: the cutoff is disabled (in-vacuum evaluation).
+    * PBCs and ``createMixedSystem`` is being used: mechanical embedding is assumed, the
+      ML subset is treated as an isolated cluster, and the cutoff is disabled.
+    * PBCs and ``createSystem`` (full ML system): the cutoff is applied.
+
+    You can override this with the ``useCoulombCutoff`` argument if you know which behavior
+    you want, for example:
+
+    >>>  system = potential.createSystem(pdb.topology, useCoulombCutoff=False)
+
     """
 
     def __init__(self, 
@@ -162,13 +178,20 @@ class TorchMDNetPotentialImpl(MLPotentialImpl):
                 filename=filename,
             )
 
-        periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()  
+        # In createMixedSystem (atoms is not None) we assume mechanical embedding, so the ML
+        # subset is treated as an isolated cluster regardless of the surrounding system's PBCs.
+        system_periodic = (topology.getPeriodicBoxVectors() is not None) or system.usesPeriodicBoundaryConditions()
+        mixed_system = atoms is not None
+        periodic = system_periodic and not mixed_system
+        # Allow the caller to override whether the Coulomb cutoff is applied. By default it is
+        # only applied when the ML potential is being evaluated under PBCs (i.e. periodic=True).
+        use_coulomb_cutoff = args.get('useCoulombCutoff', periodic)
         model = load_model(
             model_file_path,
             derivative=False,
             remove_ref_energy = args.get('remove_ref_energy', True),
             max_num_neighbors = min(args.get('max_num_neighbors', 64), numbers.shape[0]),
-            coulomb_cutoff = cutoff if periodic else None,
+            coulomb_cutoff = cutoff if use_coulomb_cutoff else None,
             static_shapes = True,
             check_errors = False
         ).to(device)

--- a/test/TestTorchMDNetPotential.py
+++ b/test/TestTorchMDNetPotential.py
@@ -19,7 +19,11 @@ class TestTorchMDNetPotential:
     def testCreatePureMLSystem(self, platform_int, model):
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
         potential = MLPotential(model)
-        system = potential.createSystem(pdb.topology, returnEnergyType='energy')
+        kwargs = {'returnEnergyType': 'energy'}
+        if model == 'aceff-2.0':
+            kwargs['coulomb_cutoff'] = 1.2
+            kwargs['useCoulombCutoff'] = True
+        system = potential.createSystem(pdb.topology, **kwargs)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
         context.setPositions(pdb.getPositions(asNumpy=True))


### PR DESCRIPTION
fixes https://github.com/openmm/openmm-ml/issues/137

For in-vacuum energy evaluations we do not want to use a coulomb cutoff as it introduces errors from the reaction field approximation it uses. 

Probably also for mechanical embedding small molecule mixed systems we also do not want to use the coulomb cutoff. This does not yet address that so is still a draft.