### PR TITLE
set gpu_preprocessing=True in FeNNix

### DIFF
--- a/openmmml/models/fennixpotential.py
+++ b/openmmml/models/fennixpotential.py
@@ -176,9 +176,9 @@ class _ComputeFeNNix:
         # Invoke the model to get the energy and forces.
         with jax.enable_x64(self.useDouble):
             if self.periodic:
-                modelOutputs = self.model.energy_and_forces(coordinates=positions, cells=cells, **self.inputs)
+                modelOutputs = self.model.energy_and_forces(coordinates=positions, cells=cells, gpu_preprocessing=True, **self.inputs)
             else:
-                modelOutputs = self.model.energy_and_forces(coordinates=positions, **self.inputs)
+                modelOutputs = self.model.energy_and_forces(coordinates=positions, gpu_preprocessing=True, **self.inputs)
             jaxEnergy, jaxForces = modelOutputs[:2]
             energy = jaxEnergy.item() * self.energyScale
             jaxForces *= self.forceScale


### PR DESCRIPTION
Default went from the fast JAX neighborlist to the slow NumPy neighborlist at some point.

https://github.com/openmm/openmm/issues/5320#issuecomment-4747181550

This patch makes sure it always hits the fast preprocessing path.
