### PR TITLE
Add code of conduct and contributor guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Moreover, project maintainers will strive to offer feedback and advice to
+ensure quality and consistency of contributions to the code.  Contributions
+from outside the group of project maintainers are strongly welcomed but the
+final decision as to whether commits are merged into the codebase rests with
+the team of project maintainers.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at 'peastman@stanford.edu'. The project team will
+review and investigate all complaints, and will respond in a way that it deems
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+## How to Contribute to OpenMM-ML Development
+
+We welcome anyone who wants to contribute to the project, whether by adding a feature,
+fixing a bug, or improving documentation.  The process is quite simple.
+
+First, it is always best to begin by opening an issue on Github that describes the change you
+want to make.  This gives everyone a chance to discuss it before you put in a lot of work.
+For bug fixes, we will confirm that the behavior is actually a bug and that the proposed fix
+is correct.  For new features, we will decide whether the proposed feature is something we
+want and discuss possible designs for it.
+
+Once everyone is in agreement, the next step is to
+[create a pull request](https://help.github.com/en/articles/about-pull-requests) with the code changes.
+For larger features, feel free to create the pull request even before the implementation is
+finished so as to get early feedback on the code.  When doing this, put the letters "WIP" at
+the start of the title of the pull request to indicate it is still a work in progress.
+
+For new features, your PR should include documentation and tests along with the implementation, as needed and appropriate.
+You may find it useful to review the OpenMM-ML [developer API documentation](https://openmm.github.io/openmm-ml/dev/api.html#developer-api).
+If you are proposing to add a new potential or embedding method, be sure to include as necessary (in addition to the
+module containing the implementation itself):
+
+* An entry point or entry points in `setup.py`.
+* A test module in `test/`.
+* Any inputs/scripts used to generate reference values for test cases in `test/data/`.
+* Updates to `devtools/requirements` and/or `.github/workflows/CI.yml` to specify any packages necessary for running the test cases.
+* A subsection in `doc/userguide.md`.
+
+The core developers will review the pull request and may suggest changes.  Simply push the
+changes to the branch that is being pulled from, and they will automatically be added to the
+pull request.  In addition, the full test suite is automatically run on every pull request,
+and rerun every time a change is added.  Once the tests are passing and everyone is satisfied
+with the code, the pull request will be merged.  Congratulations on a successful contribution!


### PR DESCRIPTION
Adds a code of conduct (identical to the main OpenMM repository's), and a contributor guide (adapted from the one in the main OpenMM repository, with a brief description of OpenMM-ML-specific guidelines for adding new features).