### PR TITLE
Add More AIMNet Models

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -122,8 +122,8 @@ create yourself.  The following pretrained model families are supported.
 | `aimnet2-rxn` | Reactive chemistry, transition states, NEB/IRC.  Limited to net-neutral systems and H, C, N, O only |
 | `aimnet` | Custom AIMNet2 models specified with the `modelPath` argument |
 
-Each pretrained family is a four-member ensemble.  The family name (e.g. `aimnet2`) selects member 0; to use a
-specific member, pass the `modelIndex` argument (0 through 3) to `createSystem()`.
+Each pretrained family is a four-member ensemble.  Pass the `modelIndex` argument (0 through 3) to `createSystem()`
+to select which member to use.  If it is omitted, member 0 is used by default.
 
 When creating AIMNet2 models, the following keyword arguments to the `MLPotential` constructor are supported.
 

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -110,12 +110,18 @@ When using MACE models, the following extra keyword arguments to `createSystem()
 ### AIMNet2
 
 The [aimnet](https://github.com/isayevlab/aimnetcentral) package can be used to create models using the pretrained
-[AIMNet2](https://doi.org/10.1039/D4SC08572H) potential.  The following model names
-are supported.
+[AIMNet2](https://doi.org/10.1039/D4SC08572H) potential.  This includes both the pretrained model and custom models you
+create yourself.  The following model names are supported.
 
 | Name | Model |
 | --- | --- |
-| `aimnet2` | Pretrained AIMNet2 models |
+| `aimnet2` | Pretrained AIMNet2 model, or a custom AIMNet2 model specified with the `modelPath` argument |
+
+When creating AIMNet2 models, the following keyword arguments to the `MLPotential` constructor are supported.
+
+| Argument | Description |
+| --- | --- |
+| `modelPath` | For custom models, the path to the file containing the model.  If omitted, the pretrained AIMNet2 model is used. |
 
 When using AIMNet2 models, the following extra keyword arguments to `createSystem()` and `createMixedSystem()` are supported.
 

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -115,13 +115,14 @@ create yourself.  The following model names are supported.
 
 | Name | Model |
 | --- | --- |
-| `aimnet2` | Pretrained AIMNet2 model, or a custom AIMNet2 model specified with the `modelPath` argument |
+| `aimnet2` | Pretrained AIMNet2 model |
+| `aimnet` | Custom AIMNet2 models specified with the `modelPath` argument |
 
 When creating AIMNet2 models, the following keyword arguments to the `MLPotential` constructor are supported.
 
 | Argument | Description |
 | --- | --- |
-| `modelPath` | For custom models, the path to the file containing the model.  If omitted, the pretrained AIMNet2 model is used. |
+| `modelPath` | For custom models (name `aimnet`), the path to the file containing the model |
 
 When using AIMNet2 models, the following extra keyword arguments to `createSystem()` and `createMixedSystem()` are supported.
 

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -123,8 +123,7 @@ create yourself.  The following pretrained model families are supported.
 | `aimnet` | Custom AIMNet2 models specified with the `modelPath` argument |
 
 Each pretrained family is a four-member ensemble.  The family name (e.g. `aimnet2`) selects member 0; to use a
-specific member, append `_0` through `_3` to the registry name (e.g. `aimnet2-wb97m-d3_2`).  The full set of
-supported names (every ensemble member and family alias) is the `openmmml.potentials` entry points in `setup.py`.
+specific member, pass the `modelIndex` argument (0 through 3) to `createSystem()`.
 
 When creating AIMNet2 models, the following keyword arguments to the `MLPotential` constructor are supported.
 
@@ -138,6 +137,7 @@ When using AIMNet2 models, the following extra keyword arguments to `createSyste
 | --- | --- |
 | `charge` | The total charge of the system.  If omitted, it is assumed to be 0. |
 | `multiplicity` | The spin multiplicity of the system.  If omitted, it is assumed to be 1. |
+| `modelIndex` | For pretrained families, the ensemble member (0 through 3) to use.  If omitted, member 0 is used.  Not supported for custom models (name `aimnet`). |
 
 ### NequIP
 

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -110,13 +110,21 @@ When using MACE models, the following extra keyword arguments to `createSystem()
 ### AIMNet2
 
 The [aimnet](https://github.com/isayevlab/aimnetcentral) package can be used to create models using the pretrained
-[AIMNet2](https://doi.org/10.1039/D4SC08572H) potential.  This includes both the pretrained model and custom models you
-create yourself.  The following model names are supported.
+[AIMNet2](https://doi.org/10.1039/D4SC08572H) potential.  This includes both the pretrained models and custom models you
+create yourself.  The following pretrained model families are supported.
 
 | Name | Model |
 | --- | --- |
-| `aimnet2` | Pretrained AIMNet2 model |
+| `aimnet2` | General organic and elemental-organic chemistry (wB97M-D3).  Covers H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I |
+| `aimnet2-2025` | B97-3c with improved intermolecular interactions.  Same element coverage as `aimnet2` |
+| `aimnet2-nse` | Open-shell systems |
+| `aimnet2-pd` | Pd catalysis (B97-3c/CPCM(THF)).  Adds the Pd element (replaces As) |
+| `aimnet2-rxn` | Reactive chemistry, transition states, NEB/IRC.  Limited to net-neutral systems and H, C, N, O only |
 | `aimnet` | Custom AIMNet2 models specified with the `modelPath` argument |
+
+Each pretrained family is a four-member ensemble.  The family name (e.g. `aimnet2`) selects member 0; to use a
+specific member, append `_0` through `_3` to the registry name (e.g. `aimnet2-wb97m-d3_2`).  The full set of
+supported names (every ensemble member and family alias) is the `openmmml.potentials` entry points in `setup.py`.
 
 When creating AIMNet2 models, the following keyword arguments to the `MLPotential` constructor are supported.
 

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -59,9 +59,11 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
 
     >>> potential = MLPotential('aimnet2')
 
-    Each family is a four-member ensemble.  A family name maps to member 0; append
-    '_0' through '_3' to select a particular member (e.g. 'aimnet2-wb97m-d3_2').  See the
-    'openmmml.potentials' entry points in setup.py for the full list of accepted names.
+    Each family is a four-member ensemble.  A family name maps to member 0; to select a
+    particular member, pass the ``modelIndex`` argument (0 through 3) to
+    ``createSystem()``:
+
+    >>> system = potential.createSystem(topology, modelIndex=2)
 
     To use a locally trained AIMNet2 model, use the name 'aimnet' and provide the
     path to the model file:
@@ -86,6 +88,7 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
                   system: openmm.System,
                   atoms: Optional[Iterable[int]],
                   forceGroup: int,
+                  modelIndex: Optional[int] = None,
                   **args):
         # Load the AIMNet2 model.
 
@@ -97,11 +100,23 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         if self.name == 'aimnet':
             if self.modelPath is None:
                 raise ValueError("No modelPath provided for local AIMNet2 model.")
+            if modelIndex is not None:
+                raise ValueError("modelIndex is not supported for local AIMNet2 models ('aimnet').")
             model = AIMNet2Calculator(self.modelPath)
         else:
-            # Any other registered name is an AIMNet2 registry name or alias; aimnet
-            # resolves it (family and ensemble member) itself.
-            model = AIMNet2Calculator(self.name)
+            # The registered name is an AIMNet2 family alias, which aimnet resolves to
+            # ensemble member 0.  If modelIndex is given, select that member instead:
+            # family aliases are not a simple prefix (e.g. member 2 of 'aimnet2-2025' is
+            # 'aimnet2-b973c-2025-d3_2'), so resolve the alias to its canonical member-0
+            # name and substitute the requested member index.
+            modelName = self.name
+            if modelIndex is not None:
+                if not 0 <= modelIndex <= 3:
+                    raise ValueError(f"modelIndex must be 0-3 for {self.name}, got {modelIndex}")
+                from aimnet.calculators.model_registry import resolve_registry_model_name
+                familyPrefix = resolve_registry_model_name(self.name).rsplit('_', 1)[0]
+                modelName = f'{familyPrefix}_{modelIndex}'
+            model = AIMNet2Calculator(modelName)
         device = torch.device(model.device)
         model.device = device
 

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -79,6 +79,16 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         The path to the locally trained AIMNet2 model if ``name`` is 'aimnet'.
     """
 
+    # (Family alias, canonical AIMNet2 registry family prefix)
+    # Model index (0-3) is appended at load time, e.g. 'aimnet2-wb97m-d3_2'.
+    KNOWN_MODELS = {
+        'aimnet2':      'aimnet2-wb97m-d3',
+        'aimnet2-2025': 'aimnet2-b973c-2025-d3',
+        'aimnet2-nse':  'aimnet2-nse',
+        'aimnet2-pd':   'aimnet2-pd',
+        'aimnet2-rxn':  'aimnet2-rxn',
+    }
+
     def __init__(self, name, modelPath=None):
         self.name = name
         self.modelPath = modelPath
@@ -97,32 +107,27 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         except ImportError as e:
             raise ImportError(f"Failed to import aimnet with error: {e}. Install from https://github.com/isayevlab/aimnetcentral.")
         import torch
-        if self.name == 'aimnet':
+        if self.name in AIMNet2PotentialImpl.KNOWN_MODELS:
+            # We select an ensemble member by substituting its index into the family's
+            # canonical member name (e.g. 'aimnet2-wb97m-d3_2'), using the prefixes in
+            # KNOWN_MODELS. We can't instead pass the family alias with
+            # AIMNet2Calculator's `ensemble_member` argument: for a registry alias that
+            # argument is silently ignored (it only applies when loading an ensemble from
+            # a HuggingFace repo), so every index would return member 0 and out-of-range
+            # values would raise nothing.
+            if not 0 <= modelIndex <= 3:
+                raise ValueError(f"modelIndex must be 0-3 for {self.name}, got {modelIndex}")
+            modelName = f'{AIMNet2PotentialImpl.KNOWN_MODELS[self.name]}_{modelIndex}'
+            model = AIMNet2Calculator(modelName)
+        elif self.name == 'aimnet':
             if self.modelPath is None:
                 raise ValueError("No modelPath provided for local AIMNet2 model.")
             if modelIndex != 0:
-                raise ValueError("modelIndex > 0 is not supported for local AIMNet2 models "
-                                 "('aimnet') -- only the model at modelPath is used.")
+                raise ValueError("modelIndex != 0 is not supported for local AIMNet2 models "
+                                 "('aimnet') -- only the model at modelPath is available.")
             model = AIMNet2Calculator(self.modelPath)
         else:
-            # The registered name is an AIMNet2 family alias. We can't just pass the
-            # alias with AIMNet2Calculator's `ensemble_member` argument: for a registry
-            # alias this argument is silently ignored (it only applies when loading an
-            # ensemble from a HuggingFace repo), so every index returns member 0 and
-            # out-of-range values raise nothing. Instead, resolve the alias to its
-            # canonical member-0 name and substitute the requested member index. Family
-            # aliases are not a simple prefix (e.g. member 2 of 'aimnet2-2025' is
-            # 'aimnet2-b973c-2025-d3_2'), hence the resolve step. 
-
-            # Validate the modelIndex range for the AIMNet2 family, as AIMNet doesn't
-            # do this directly (it just complains about a missing model or silently
-            # ignores for family aliases).
-            if not 0 <= modelIndex <= 3:
-                raise ValueError(f"modelIndex must be 0-3 for {self.name}, got {modelIndex}")
-            from aimnet.calculators.model_registry import resolve_registry_model_name
-            familyPrefix = resolve_registry_model_name(self.name).rsplit('_', 1)[0]
-            modelName = f'{familyPrefix}_{modelIndex}'
-            model = AIMNet2Calculator(modelName)
+            raise ValueError(f"Unsupported AIMNet2 model: {self.name}")
         device = torch.device(model.device)
         model.device = device
 

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -59,9 +59,9 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
 
     >>> potential = MLPotential('aimnet2')
 
-    Each family is a four-member ensemble.  A family name maps to member 0; to select a
-    particular member, pass the ``modelIndex`` argument (0 through 3) to
-    ``createSystem()``:
+    Each family is a four-member ensemble.  Pass the ``modelIndex`` argument (0 through 3)
+    to ``createSystem()`` to select which member to use.  If it is omitted, member 0 is
+    used by default:
 
     >>> system = potential.createSystem(topology, modelIndex=2)
 
@@ -88,7 +88,7 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
                   system: openmm.System,
                   atoms: Optional[Iterable[int]],
                   forceGroup: int,
-                  modelIndex: Optional[int] = None,
+                  modelIndex: int = 0,
                   **args):
         # Load the AIMNet2 model.
 
@@ -100,22 +100,28 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         if self.name == 'aimnet':
             if self.modelPath is None:
                 raise ValueError("No modelPath provided for local AIMNet2 model.")
-            if modelIndex is not None:
-                raise ValueError("modelIndex is not supported for local AIMNet2 models ('aimnet').")
+            if modelIndex != 0:
+                raise ValueError("modelIndex > 0 is not supported for local AIMNet2 models "
+                                 "('aimnet') -- only the model at modelPath is used.")
             model = AIMNet2Calculator(self.modelPath)
         else:
-            # The registered name is an AIMNet2 family alias, which aimnet resolves to
-            # ensemble member 0.  If modelIndex is given, select that member instead:
-            # family aliases are not a simple prefix (e.g. member 2 of 'aimnet2-2025' is
-            # 'aimnet2-b973c-2025-d3_2'), so resolve the alias to its canonical member-0
-            # name and substitute the requested member index.
-            modelName = self.name
-            if modelIndex is not None:
-                if not 0 <= modelIndex <= 3:
-                    raise ValueError(f"modelIndex must be 0-3 for {self.name}, got {modelIndex}")
-                from aimnet.calculators.model_registry import resolve_registry_model_name
-                familyPrefix = resolve_registry_model_name(self.name).rsplit('_', 1)[0]
-                modelName = f'{familyPrefix}_{modelIndex}'
+            # The registered name is an AIMNet2 family alias. We can't just pass the
+            # alias with AIMNet2Calculator's `ensemble_member` argument: for a registry
+            # alias this argument is silently ignored (it only applies when loading an
+            # ensemble from a HuggingFace repo), so every index returns member 0 and
+            # out-of-range values raise nothing. Instead, resolve the alias to its
+            # canonical member-0 name and substitute the requested member index. Family
+            # aliases are not a simple prefix (e.g. member 2 of 'aimnet2-2025' is
+            # 'aimnet2-b973c-2025-d3_2'), hence the resolve step. 
+
+            # Validate the modelIndex range for the AIMNet2 family, as AIMNet doesn't
+            # do this directly (it just complains about a missing model or silently
+            # ignores for family aliases).
+            if not 0 <= modelIndex <= 3:
+                raise ValueError(f"modelIndex must be 0-3 for {self.name}, got {modelIndex}")
+            from aimnet.calculators.model_registry import resolve_registry_model_name
+            familyPrefix = resolve_registry_model_name(self.name).rsplit('_', 1)[0]
+            modelName = f'{familyPrefix}_{modelIndex}'
             model = AIMNet2Calculator(modelName)
         device = torch.device(model.device)
         model.device = device

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -48,12 +48,20 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
 
     The AIMNet2 potential is constructed using `aimnet` to build a PyTorch model,
     and then integrated into the OpenMM System using a PythonForce.  This
-    implementation supports both the pretrained AIMNet2 model and locally trained
+    implementation supports both the pretrained AIMNet2 models and locally trained
     AIMNet2 models.
 
-    To use the pretrained AIMNet2 model, specify the model by name:
+    To use a pretrained model, specify a supported AIMNet2 model name.  The supported
+    model families are 'aimnet2' (general organic/elemental-organic), 'aimnet2-2025'
+    (improved intermolecular interactions), 'aimnet2-nse' (open-shell systems and
+    radicals), 'aimnet2-pd' (Pd catalysis), and 'aimnet2-rxn' (reactive chemistry).  For
+    example:
 
     >>> potential = MLPotential('aimnet2')
+
+    Each family is a four-member ensemble.  A family name maps to member 0; append
+    '_0' through '_3' to select a particular member (e.g. 'aimnet2-wb97m-d3_2').  See the
+    'openmmml.potentials' entry points in setup.py for the full list of accepted names.
 
     To use a locally trained AIMNet2 model, use the name 'aimnet' and provide the
     path to the model file:
@@ -63,8 +71,8 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
     Attributes
     ----------
     name : str
-        The name of the AIMNet2 model.  Options are 'aimnet2' for the pretrained
-        model and 'aimnet' for a locally trained model.
+        The name of the AIMNet2 model.  This is either an AIMNet2 registry model name
+        or alias for a pretrained model, or 'aimnet' for a locally trained model.
     modelPath : str
         The path to the locally trained AIMNet2 model if ``name`` is 'aimnet'.
     """
@@ -86,14 +94,14 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         except ImportError as e:
             raise ImportError(f"Failed to import aimnet with error: {e}. Install from https://github.com/isayevlab/aimnetcentral.")
         import torch
-        if self.name == 'aimnet2':
-            model = AIMNet2Calculator('aimnet2')
-        elif self.name == 'aimnet':
+        if self.name == 'aimnet':
             if self.modelPath is None:
                 raise ValueError("No modelPath provided for local AIMNet2 model.")
             model = AIMNet2Calculator(self.modelPath)
         else:
-            raise ValueError(f"Unsupported AIMNet2 model: {self.name}")
+            # Any other registered name is an AIMNet2 registry name or alias; aimnet
+            # resolves it (family and ensemble member) itself.
+            model = AIMNet2Calculator(self.name)
         device = torch.device(model.device)
         model.device = device
 
@@ -121,12 +129,12 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
     def getMLLongRange(self) -> bool | None:
         # NOTE: By default, creating an AIMNet2Calculator gives a coulomb_method
         # of "simple" (which changes to the cutoff-based "dsf" method with PBCs;
-        # see https://isayevlab.github.io/aimnetcentral/long_range/).  OpenMM-ML
-        # does not expose any option to change this; if we change this behavior
-        # in the future, or other AIMNet models we support in the future have
-        # different behavior, this must be updated.  A user-supplied local model
-        # (modelPath) is assumed to use this same default coulomb behavior; if a
-        # custom model does not, this would need revisiting.
+        # see https://isayevlab.github.io/aimnetcentral/long_range/).  This is a
+        # property of the calculator rather than the individual model weights, so it
+        # is assumed to hold for every supported registry family as well as for a
+        # user-supplied local model (modelPath).  OpenMM-ML does not expose any
+        # option to change this; if we change this behavior in the future, or a
+        # supported model has different behavior, this must be updated.
         return False
 
 def _computeAIMNet2(state, model, numbers, charge, multiplicity, indices, periodic):

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -55,17 +55,18 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
 
     >>> potential = MLPotential('aimnet2')
 
-    To use a locally trained AIMNet2 model, provide the path to the model file:
+    To use a locally trained AIMNet2 model, use the name 'aimnet' and provide the
+    path to the model file:
 
-    >>> potential = MLPotential('aimnet2', modelPath='mymodel.pt')
+    >>> potential = MLPotential('aimnet', modelPath='mymodel.pt')
 
     Attributes
     ----------
     name : str
-        The name of the AIMNet2 model.
+        The name of the AIMNet2 model.  Options are 'aimnet2' for the pretrained
+        model and 'aimnet' for a locally trained model.
     modelPath : str
-        The path to the locally trained AIMNet2 model, or ``None`` to use the
-        pretrained model.
+        The path to the locally trained AIMNet2 model if ``name`` is 'aimnet'.
     """
 
     def __init__(self, name, modelPath=None):
@@ -85,7 +86,14 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         except ImportError as e:
             raise ImportError(f"Failed to import aimnet with error: {e}. Install from https://github.com/isayevlab/aimnetcentral.")
         import torch
-        model = AIMNet2Calculator(self.modelPath if self.modelPath is not None else 'aimnet2')
+        if self.name == 'aimnet2':
+            model = AIMNet2Calculator('aimnet2')
+        elif self.name == 'aimnet':
+            if self.modelPath is None:
+                raise ValueError("No modelPath provided for local AIMNet2 model.")
+            model = AIMNet2Calculator(self.modelPath)
+        else:
+            raise ValueError(f"Unsupported AIMNet2 model: {self.name}")
         device = torch.device(model.device)
         model.device = device
 

--- a/openmmml/models/aimnet2potential.py
+++ b/openmmml/models/aimnet2potential.py
@@ -39,21 +39,38 @@ import numpy as np
 class AIMNet2PotentialImplFactory(MLPotentialImplFactory):
     """This is the factory that creates AIMNet2PotentialImpl objects."""
 
-    def createImpl(self, name: str, **args) -> MLPotentialImpl:
-        return AIMNet2PotentialImpl(name)
+    def createImpl(self, name: str, modelPath: Optional[str] = None, **args) -> MLPotentialImpl:
+        return AIMNet2PotentialImpl(name, modelPath)
 
 
 class AIMNet2PotentialImpl(MLPotentialImpl):
     """This is the MLPotentialImpl implementing the AIMNet2 potential.
 
     The AIMNet2 potential is constructed using `aimnet` to build a PyTorch model,
-    and then integrated into the OpenMM System using a TorchForce.  To use it, specify the model by name:
+    and then integrated into the OpenMM System using a PythonForce.  This
+    implementation supports both the pretrained AIMNet2 model and locally trained
+    AIMNet2 models.
+
+    To use the pretrained AIMNet2 model, specify the model by name:
 
     >>> potential = MLPotential('aimnet2')
+
+    To use a locally trained AIMNet2 model, provide the path to the model file:
+
+    >>> potential = MLPotential('aimnet2', modelPath='mymodel.pt')
+
+    Attributes
+    ----------
+    name : str
+        The name of the AIMNet2 model.
+    modelPath : str
+        The path to the locally trained AIMNet2 model, or ``None`` to use the
+        pretrained model.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, modelPath=None):
         self.name = name
+        self.modelPath = modelPath
 
     def addForces(self,
                   topology: openmm.app.Topology,
@@ -68,7 +85,7 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         except ImportError as e:
             raise ImportError(f"Failed to import aimnet with error: {e}. Install from https://github.com/isayevlab/aimnetcentral.")
         import torch
-        model = AIMNet2Calculator('aimnet2')
+        model = AIMNet2Calculator(self.modelPath if self.modelPath is not None else 'aimnet2')
         device = torch.device(model.device)
         model.device = device
 
@@ -99,7 +116,9 @@ class AIMNet2PotentialImpl(MLPotentialImpl):
         # see https://isayevlab.github.io/aimnetcentral/long_range/).  OpenMM-ML
         # does not expose any option to change this; if we change this behavior
         # in the future, or other AIMNet models we support in the future have
-        # different behavior, this must be updated.
+        # different behavior, this must be updated.  A user-supplied local model
+        # (modelPath) is assumed to use this same default coulomb behavior; if a
+        # custom model does not, this would need revisiting.
         return False
 
 def _computeAIMNet2(state, model, numbers, charge, multiplicity, indices, periodic):

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=['numpy', 'openmm >= 8.5.2'],
     entry_points={
         'openmmml.potentials': [
+            'aimnet = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'ani1ccx = openmmml.models.anipotential:ANIPotentialImplFactory',
             'ani2x = openmmml.models.anipotential:ANIPotentialImplFactory',

--- a/setup.py
+++ b/setup.py
@@ -43,43 +43,14 @@ setup(
         'openmmml.potentials': [
             # Custom AIMNet2 model supplied by path.
             'aimnet = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            # AIMNet2 registry models: the canonical name and family alias for each
-            # supported model from the aimnet model registry
-            # (aimnet/calculators/model_registry.yaml) is passed straight through to
-            # AIMNet2Calculator, which resolves the family and ensemble member.  The
-            # trailing _0.._3 selects the ensemble member; the short alias for each
-            # family (e.g. 'aimnet2') maps to member 0.  Legacy underscore aliases from
-            # the registry (e.g. 'aimnet2_rxn_0') are intentionally not registered.
-            # wb97m-d3 family.
-            'aimnet2-wb97m-d3_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-wb97m-d3_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-wb97m-d3_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-wb97m-d3_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # AIMNet2 pretrained families.  Each family name is passed to
+            # AIMNet2Calculator, which resolves it to ensemble member 0.  A specific
+            # member (0..3) is selected with the modelIndex argument to createSystem()
+            # (see openmmml/models/aimnet2potential.py).
             'aimnet2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-wb97m = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            # b973c-2025-d3 family.
-            'aimnet2-b973c-2025-d3_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-b973c-2025-d3_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-b973c-2025-d3_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-b973c-2025-d3_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2-2025 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            # nse family (open-shell systems and radicals).
-            'aimnet2-nse_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-nse_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-nse_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-nse_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2-nse = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            # pd family (Pd catalysis).
-            'aimnet2-pd_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-pd_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-pd_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-pd_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2-pd = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            # rxn family (reactive chemistry; net-neutral, H/C/N/O only).
-            'aimnet2-rxn_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-rxn_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-rxn_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
-            'aimnet2-rxn_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2-rxn = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'ani1ccx = openmmml.models.anipotential:ANIPotentialImplFactory',
             'ani2x = openmmml.models.anipotential:ANIPotentialImplFactory',

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,46 @@ setup(
     install_requires=['numpy', 'openmm >= 8.5.2'],
     entry_points={
         'openmmml.potentials': [
+            # Custom AIMNet2 model supplied by path.
             'aimnet = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # AIMNet2 registry models: the canonical name and family alias for each
+            # supported model from the aimnet model registry
+            # (aimnet/calculators/model_registry.yaml) is passed straight through to
+            # AIMNet2Calculator, which resolves the family and ensemble member.  The
+            # trailing _0.._3 selects the ensemble member; the short alias for each
+            # family (e.g. 'aimnet2') maps to member 0.  Legacy underscore aliases from
+            # the registry (e.g. 'aimnet2_rxn_0') are intentionally not registered.
+            # wb97m-d3 family.
+            'aimnet2-wb97m-d3_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-wb97m-d3_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-wb97m-d3_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-wb97m-d3_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'aimnet2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-wb97m = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # b973c-2025-d3 family.
+            'aimnet2-b973c-2025-d3_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-b973c-2025-d3_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-b973c-2025-d3_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-b973c-2025-d3_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-2025 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # nse family (open-shell systems and radicals).
+            'aimnet2-nse_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-nse_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-nse_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-nse_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-nse = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # pd family (Pd catalysis).
+            'aimnet2-pd_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-pd_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-pd_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-pd_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-pd = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            # rxn family (reactive chemistry; net-neutral, H/C/N/O only).
+            'aimnet2-rxn_0 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-rxn_1 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-rxn_2 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-rxn_3 = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
+            'aimnet2-rxn = openmmml.models.aimnet2potential:AIMNet2PotentialImplFactory',
             'ani1ccx = openmmml.models.anipotential:ANIPotentialImplFactory',
             'ani2x = openmmml.models.anipotential:ANIPotentialImplFactory',
             'ase = openmmml.models.asepotential:ASEPotentialImplFactory',

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -72,6 +72,17 @@ class TestAIMNet2:
         with pytest.raises(ValueError):
             self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"), modelIndex=2)
 
+    def testUnsupportedModel(self, platform_int):
+        # A name that reaches the impl but isn't a known family (e.g. the legacy b973c
+        # family, a raw member alias, or a typo) is rejected.  Names are normally gated by
+        # the registered entry points before this point, so we exercise the impl directly.
+        from openmmml.models.aimnet2potential import AIMNet2PotentialImpl
+        pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
+        for name in ("aimnet2-b973c", "aimnet2_wb97m_d3_2", "not-a-model"):
+            impl = AIMNet2PotentialImpl(name)
+            with pytest.raises(ValueError, match="Unsupported AIMNet2 model"):
+                impl.addForces(pdb.topology, mm.System(), None, 0)
+
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))
         potential = MLPotential("aimnet2", charge=0, multiplicity=1)

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -17,9 +17,10 @@ test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 @pytest.mark.parametrize("platform_int", list(platform_ints))
 class TestAIMNet2:
-    def _toluene_energy(self, name, platform_int, **mlPotentialArgs):
+    def _toluene_energy(self, name, platform_int, modelPath=None, **createSystemArgs):
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
-        system = MLPotential(name, **mlPotentialArgs).createSystem(pdb.topology)
+        potentialArgs = {} if modelPath is None else {"modelPath": modelPath}
+        system = MLPotential(name, **potentialArgs).createSystem(pdb.topology, **createSystemArgs)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
         context.setPositions(pdb.getPositions(asNumpy=True))
@@ -51,6 +52,24 @@ class TestAIMNet2:
         from aimnet.calculators.calculator import get_model_path
         energy = self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"))
         assert np.isclose(energy, self.familyEnergies["aimnet2"], rtol=rtol)
+
+    def testModelIndex(self, platform_int):
+        # The family name selects ensemble member 0, so modelIndex=0 reproduces the
+        # family default energy while a different member gives a slightly different energy.
+        # Check they're relatively similar but do actually differ.
+        default = self._toluene_energy("aimnet2", platform_int)
+        member0 = self._toluene_energy("aimnet2", platform_int, modelIndex=0)
+        member2 = self._toluene_energy("aimnet2", platform_int, modelIndex=2)
+        assert np.isclose(default, member0, rtol=rtol)
+        assert abs(default - member2) > 0.1
+
+    def testInvalidModelIndex(self, platform_int):
+        # An out-of-range member and modelIndex on a local model both raise ValueError.
+        from aimnet.calculators.calculator import get_model_path
+        with pytest.raises(ValueError):
+            self._toluene_energy("aimnet2", platform_int, modelIndex=4)
+        with pytest.raises(ValueError):
+            self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"), modelIndex=0)
 
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -17,18 +17,20 @@ test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 @pytest.mark.parametrize("platform_int", list(platform_ints))
 class TestAIMNet2:
-    # useLocalModel=True loads the pretrained model via an explicit modelPath
-    # (resolving its on-disk location), which should give identical results to
-    # loading it by name.
+    # useLocalModel=True loads the pretrained model as a custom model via the
+    # 'aimnet' name and an explicit modelPath, which should give identical
+    # results to loading it by the 'aimnet2' name.
     @pytest.mark.parametrize("useLocalModel", [False, True])
     def testCreatePureMLSystem(self, platform_int, useLocalModel):
         if useLocalModel:
             from aimnet.calculators.calculator import get_model_path
+            name = "aimnet"
             modelPath = get_model_path("aimnet2")
         else:
+            name = "aimnet2"
             modelPath = None
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
-        potential = MLPotential("aimnet2", modelPath=modelPath, charge=0, multiplicity=1)
+        potential = MLPotential(name, modelPath=modelPath, charge=0, multiplicity=1)
         system = potential.createSystem(pdb.topology)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -17,30 +17,40 @@ test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 @pytest.mark.parametrize("platform_int", list(platform_ints))
 class TestAIMNet2:
-    # useLocalModel=True loads the pretrained model as a custom model via the
-    # 'aimnet' name and an explicit modelPath, which should give identical
-    # results to loading it by the 'aimnet2' name.
-    @pytest.mark.parametrize("useLocalModel", [False, True])
-    def testCreatePureMLSystem(self, platform_int, useLocalModel):
-        if useLocalModel:
-            from aimnet.calculators.calculator import get_model_path
-            name = "aimnet"
-            modelPath = get_model_path("aimnet2")
-        else:
-            name = "aimnet2"
-            modelPath = None
+    def _toluene_energy(self, name, platform_int, **mlPotentialArgs):
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
-        potential = MLPotential(name, modelPath=modelPath, charge=0, multiplicity=1)
-        system = potential.createSystem(pdb.topology)
+        system = MLPotential(name, **mlPotentialArgs).createSystem(pdb.topology)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
-        positionsOriginal = pdb.getPositions(asNumpy=True)
-        energyRef = -713468.0026230365 # in kJ/mol, calculated using the AIMNet2ASE
-        for i in range(10):
-            positions = positionsOriginal + i * 0.5 * unit.nanometers # translate molecule to test PBC
-            context.setPositions(positions)
-            energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
-            assert np.isclose(energyRef, energyML, rtol=rtol)
+        context.setPositions(pdb.getPositions(asNumpy=True))
+        return context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+
+    # Reference toluene energies (kJ/mol) for the pretrained families, calculated with
+    # AIMNet2ASE (see test/data/toluene/aimnet2_energies.py).  Toluene is neutral and
+    # H/C only, so it is compatible with every family, including rxn (net-neutral,
+    # H/C/N/O only).  Energy references differ across families (rxn in particular uses a
+    # learned, shifted scale), so these values are not comparable to one another.
+    familyEnergies = {
+        "aimnet2": -713468.0026230365,
+        "aimnet2-2025": -712625.9531791345,
+        "aimnet2-nse": -713470.4078623096,
+        "aimnet2-pd": -712635.0374879715,
+        "aimnet2-rxn": -208.3835827516966,
+    }
+
+    @pytest.mark.parametrize("model,energyRef", list(familyEnergies.items()))
+    def testCreateModels(self, platform_int, model, energyRef):
+        # Each pretrained family reproduces the reference energy computed
+        # independently with AIMNet2ASE.
+        assert np.isclose(self._toluene_energy(model, platform_int), energyRef, rtol=rtol)
+
+    def testLocalModel(self, platform_int):
+        # Loading the pretrained aimnet2 model as a custom model via the 'aimnet' name
+        # and an explicit modelPath gives the same energy as loading it by the 'aimnet2'
+        # name (tested in testCreateModels).
+        from aimnet.calculators.calculator import get_model_path
+        energy = self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"))
+        assert np.isclose(energy, self.familyEnergies["aimnet2"], rtol=rtol)
 
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -17,9 +17,18 @@ test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 @pytest.mark.parametrize("platform_int", list(platform_ints))
 class TestAIMNet2:
-    def testCreatePureMLSystem(self, platform_int):
+    # useLocalModel=True loads the pretrained model via an explicit modelPath
+    # (resolving its on-disk location), which should give identical results to
+    # loading it by name.
+    @pytest.mark.parametrize("useLocalModel", [False, True])
+    def testCreatePureMLSystem(self, platform_int, useLocalModel):
+        if useLocalModel:
+            from aimnet.calculators.calculator import get_model_path
+            modelPath = get_model_path("aimnet2")
+        else:
+            modelPath = None
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
-        potential = MLPotential("aimnet2", charge=0, multiplicity=1)
+        potential = MLPotential("aimnet2", modelPath=modelPath, charge=0, multiplicity=1)
         system = potential.createSystem(pdb.topology)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
@@ -30,21 +39,6 @@ class TestAIMNet2:
             context.setPositions(positions)
             energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
             assert np.isclose(energyRef, energyML, rtol=rtol)
-
-    def testLocalModelPath(self, platform_int):
-        # Load the pretrained model via an explicit modelPath (resolving its
-        # on-disk location) and check it gives the same energy as loading by name.
-        from aimnet.calculators.calculator import get_model_path
-        modelPath = get_model_path("aimnet2")
-        pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
-        potential = MLPotential("aimnet2", modelPath=modelPath, charge=0, multiplicity=1)
-        system = potential.createSystem(pdb.topology)
-        platform = mm.Platform.getPlatform(platform_int)
-        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
-        context.setPositions(pdb.getPositions(asNumpy=True))
-        energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
-        energyRef = -713468.0026230365 # in kJ/mol, calculated using the AIMNet2ASE
-        assert np.isclose(energyRef, energyML, rtol=rtol)
 
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -31,6 +31,21 @@ class TestAIMNet2:
             energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
             assert np.isclose(energyRef, energyML, rtol=rtol)
 
+    def testLocalModelPath(self, platform_int):
+        # Load the pretrained model via an explicit modelPath (resolving its
+        # on-disk location) and check it gives the same energy as loading by name.
+        from aimnet.calculators.calculator import get_model_path
+        modelPath = get_model_path("aimnet2")
+        pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
+        potential = MLPotential("aimnet2", modelPath=modelPath, charge=0, multiplicity=1)
+        system = potential.createSystem(pdb.topology)
+        platform = mm.Platform.getPlatform(platform_int)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
+        context.setPositions(pdb.getPositions(asNumpy=True))
+        energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        energyRef = -713468.0026230365 # in kJ/mol, calculated using the AIMNet2ASE
+        assert np.isclose(energyRef, energyML, rtol=rtol)
+
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))
         potential = MLPotential("aimnet2", charge=0, multiplicity=1)

--- a/test/TestAIMNet2Potential.py
+++ b/test/TestAIMNet2Potential.py
@@ -64,12 +64,13 @@ class TestAIMNet2:
         assert abs(default - member2) > 0.1
 
     def testInvalidModelIndex(self, platform_int):
-        # An out-of-range member and modelIndex on a local model both raise ValueError.
+        # An out-of-range member and a non-default modelIndex on a local model both raise
+        # ValueError.
         from aimnet.calculators.calculator import get_model_path
         with pytest.raises(ValueError):
             self._toluene_energy("aimnet2", platform_int, modelIndex=4)
         with pytest.raises(ValueError):
-            self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"), modelIndex=0)
+            self._toluene_energy("aimnet", platform_int, modelPath=get_model_path("aimnet2"), modelIndex=2)
 
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))

--- a/test/data/toluene/aimnet2_energies.py
+++ b/test/data/toluene/aimnet2_energies.py
@@ -11,5 +11,13 @@ results['toluene'] = atoms.get_potential_energy()
 atoms = ase.io.read('../alanine-dipeptide/alanine-dipeptide-explicit.pdb')
 atoms.calc = AIMNet2ASE('aimnet2')
 results['alanine-dipeptide-explicit'] = atoms.get_potential_energy()
+
+# Toluene (neutral, H/C only, compatible with every family including rxn) energies
+# for the other pretrained families.
+for name in ['aimnet2-2025', 'aimnet2-nse', 'aimnet2-pd', 'aimnet2-rxn']:
+    atoms = ase.io.read('toluene.pdb')
+    atoms.calc = AIMNet2ASE(name)
+    results[f'toluene ({name})'] = atoms.get_potential_energy()
+
 for key in results:
     print(f'{key}: {(results[key]*ev/item).value_in_unit(kilojoules_per_mole)}')


### PR DESCRIPTION
As discussed in https://github.com/openmm/openmm-ml/pull/156, this PR adds more AIMNet models.

I've included all non-legacy AIMNet2 models (there was no great reason for excluding `aimnet2-pd` and `aimnet2-rxn` other than I thought they'd be used less and was trying to avoid bloating the list of models too much).

I've kept the translation invariance test only for the solvated alanine dipeptide as it's periodic, but can add this back for the non-periodic toluene system if preferred.