### PR TITLE
[bug] MACE model dtype precision is applied to model as well as inputs. 

### DIFF
--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -203,6 +203,7 @@ class MACEPotentialImpl(MLPotentialImpl):
             raise ValueError(f"Unsupported precision {precision} for the model. Supported values are 'single' and 'double'.")
         if dtype != modelDefaultDtype:
             print(f"Model dtype is {modelDefaultDtype} and requested dtype is {dtype}. The model will be converted to the requested dtype.")
+            model = model.to(dtype)
 
         # One hot encoding of atomic numbers
 

--- a/test/TestMACEPotential.py
+++ b/test/TestMACEPotential.py
@@ -15,6 +15,19 @@ test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 @pytest.mark.parametrize("platform_int", list(platform_ints))
 class TestMACE:
+
+    # Reference energies are calculated with MACECalculator
+    refEnergy = {
+        'mace-off23-small': -713468.6327560507,
+        'mace-off23-medium': -713468.0563706581,
+        'mace-off23-large': -713467.7476380612,
+        'mace-off24-medium': -713467.9394350434,
+        'mace-mpa-0-medium': -8839.299589829867,
+        'mace-omat-0-small': -8726.63865431241,
+        'mace-omat-0-medium': -8679.026847088873,
+        'mace-omol-0-extra-large': -712903.4934289698
+    }
+
     @pytest.mark.parametrize("model", ['mace-off23-small', 'mace-off23-medium', 'mace-off23-large', 'mace-off24-medium',
                                        'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium', 'mace-omol-0-extra-large'])
     def testCreatePureMLSystem(self, platform_int, model):
@@ -25,16 +38,7 @@ class TestMACE:
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
         context.setPositions(pdb.getPositions(asNumpy=True))
         energyML = context.getState(energy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
-        # Reference energies are calculated with MACECalculator
-        refEnergy = {'mace-off23-small': -713468.6327560507,
-                     'mace-off23-medium': -713468.0563706581,
-                     'mace-off23-large': -713467.7476380612,
-                     'mace-off24-medium': -713467.9394350434,
-                     'mace-mpa-0-medium': -8839.299589829867,
-                     'mace-omat-0-small': -8726.63865431241,
-                     'mace-omat-0-medium': -8679.026847088873,
-                     'mace-omol-0-extra-large': -712903.4934289698}
-        assert np.isclose(refEnergy[model], energyML, rtol=1e-6)
+        assert np.isclose(self.refEnergy[model], energyML, rtol=1e-6)
 
     def testPeriodicSystem(self, platform_int):
         pdb = app.PDBFile(os.path.join(test_data_dir, "alanine-dipeptide", "alanine-dipeptide-explicit.pdb"))
@@ -73,15 +77,28 @@ class TestMACE:
         assert np.isclose(mixedEnergy, interpEnergy1, rtol=1e-5)
         assert np.isclose(mmEnergy, interpEnergy2, rtol=1e-5)
 
-    @pytest.mark.parametrize("precision,rtol", [("single", 1e-5), ("double", 1e-6)])
-    def testPrecision(self, platform_int, precision, rtol):
+    @pytest.mark.parametrize("precision", ["single", "double"])
+    def testPrecisionApplied(self, platform_int, precision):
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
         potential = MLPotential('mace-off23-small')
+
         # specifying precision single/double.
         system = potential.createSystem(pdb.topology, returnEnergyType='energy', precision=precision)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
         context.setPositions(pdb.getPositions(asNumpy=True))
-        energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
-        # Reference energy from testCreatePureMLSystem above - slightly looser tolerance for single precision
-        assert np.isclose(-713468.6327560507, energyML, rtol=rtol)
+
+        # Inconsistent dtypes will crash the simulation.
+        context_values = context.getState(energy=True, forces=True, positions=True, velocities=True)
+
+        # the energy should be physically meaningful under
+        # both precisions
+        energyML = (
+            context_values
+            .getPotentialEnergy()
+            .value_in_unit(unit.kilojoules_per_mole)
+        )
+        assert np.isfinite(energyML), \
+            "Energy is not finite under precision {}".format(precision)
+        assert np.isclose(energyML, self.refEnergy['mace-off23-small'], rtol=1e-6),\
+            "Energy is not close to reference under precision {}".format(precision)

--- a/test/TestMACEPotential.py
+++ b/test/TestMACEPotential.py
@@ -75,16 +75,13 @@ class TestMACE:
 
     @pytest.mark.parametrize("precision,rtol", [("single", 1e-5), ("double", 1e-6)])
     def testPrecision(self, platform_int, precision, rtol):
-        # MACE-OFF23 is distributed as a float64 checkpoint, so requesting 'single'
-        # exercises the conversion path. The model itself has to be converted and not
-        # only the inputs, otherwise float32 inputs meet float64 weights and this
-        # raises "RuntimeError: both inputs should have same dtype".
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
         potential = MLPotential('mace-off23-small')
+        # specifying precision single/double.
         system = potential.createSystem(pdb.topology, returnEnergyType='energy', precision=precision)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
         context.setPositions(pdb.getPositions(asNumpy=True))
         energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
-        # Reference energy is calculated with MACECalculator
+        # Reference energy from testCreatePureMLSystem above - slightly looser tolerance for single precision
         assert np.isclose(-713468.6327560507, energyML, rtol=rtol)

--- a/test/TestMACEPotential.py
+++ b/test/TestMACEPotential.py
@@ -82,22 +82,16 @@ class TestMACE:
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
         potential = MLPotential('mace-off23-small')
 
-        # specifying precision single/double.
+        # Specifying precision single/double.
         system = potential.createSystem(pdb.topology, returnEnergyType='energy', precision=precision)
         platform = mm.Platform.getPlatform(platform_int)
         context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
-        context.setPositions(pdb.getPositions(asNumpy=True))
+        context.setPositions(pdb.positions)
 
         # Inconsistent dtypes will crash the simulation.
-        context_values = context.getState(energy=True, forces=True, positions=True, velocities=True)
+        energyML = context.getState(energy=True, forces=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
 
-        # the energy should be physically meaningful under
-        # both precisions
-        energyML = (
-            context_values
-            .getPotentialEnergy()
-            .value_in_unit(unit.kilojoules_per_mole)
-        )
+        # The energy should be physically meaningful under both precisions
         assert np.isfinite(energyML), \
             "Energy is not finite under precision {}".format(precision)
         assert np.isclose(energyML, self.refEnergy['mace-off23-small'], rtol=1e-6),\

--- a/test/TestMACEPotential.py
+++ b/test/TestMACEPotential.py
@@ -72,3 +72,19 @@ class TestMACE:
         interpEnergy2 = interpContext.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
         assert np.isclose(mixedEnergy, interpEnergy1, rtol=1e-5)
         assert np.isclose(mmEnergy, interpEnergy2, rtol=1e-5)
+
+    @pytest.mark.parametrize("precision,rtol", [("single", 1e-5), ("double", 1e-6)])
+    def testPrecision(self, platform_int, precision, rtol):
+        # MACE-OFF23 is distributed as a float64 checkpoint, so requesting 'single'
+        # exercises the conversion path. The model itself has to be converted and not
+        # only the inputs, otherwise float32 inputs meet float64 weights and this
+        # raises "RuntimeError: both inputs should have same dtype".
+        pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
+        potential = MLPotential('mace-off23-small')
+        system = potential.createSystem(pdb.topology, returnEnergyType='energy', precision=precision)
+        platform = mm.Platform.getPlatform(platform_int)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), platform)
+        context.setPositions(pdb.getPositions(asNumpy=True))
+        energyML = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        # Reference energy is calculated with MACECalculator
+        assert np.isclose(-713468.6327560507, energyML, rtol=rtol)


### PR DESCRIPTION
`MACEPotentialImpl.addForces()` accepts a `precision` argument which logs an intent to set the model precision if `modelDefaultDtype != precision`. The function sets the precision for the inputs but not the model - which causes a crash due to the `dtype` inconsistency. 

This bug-fix is a single-line edit plus test. Adding `model = model.to(dtype)`, so that the code fulfills the intent stated by the existing print statement.

The test validates that the energies from single/double precision are approximately equal (within a tolerance of 1e-5 for single precision against a reference energy from double precision). 