### PR TITLE
Add MACELES-OFF pretrained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The current release of OpenMM-ML supports the following potential functions.
 
 - [MACE](https://arxiv.org/abs/2206.07697) models, including the pre-trained [MACE-OFF23](https://arxiv.org/abs/2312.15211),
   [MACE-MPA-0](https://github.com/ACEsuit/mace-foundations), [MACE-OMAT-0](https://github.com/ACEsuit/mace-foundations),
-  and MACE-OMOL-0 models, utilizing the [MACE implementation](https://github.com/ACEsuit/mace).
+  [MACELES-OFF](https://github.com/ChengUCB/les_fit), and MACE-OMOL-0 models, utilizing the [MACE implementation](https://github.com/ACEsuit/mace).
 
 - The pretrained [AIMNet2](https://doi.org/10.1039/D4SC08572H) model.
 

--- a/devtools/requirements/mace-aimnet-torchmd.txt
+++ b/devtools/requirements/mace-aimnet-torchmd.txt
@@ -5,4 +5,4 @@ torchmd-net
 ase
 huggingface-hub
 torchani
-git+https://github.com/ChengUCB/les
+git+https://github.com/ChengUCB/les@v0.2.0

--- a/devtools/requirements/mace-aimnet-torchmd.txt
+++ b/devtools/requirements/mace-aimnet-torchmd.txt
@@ -5,3 +5,4 @@ torchmd-net
 ase
 huggingface-hub
 torchani
+git+https://github.com/ChengUCB/les

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -89,6 +89,7 @@ are supported.
 | `mace-mpa-0-medium` | Pretrained [MACE-MPA-0](https://github.com/ACEsuit/mace-foundations) model |
 | `mace-omat-0-small`<br>`mace-omat-0-medium` | Pretrained [MACE-OMAT-0](https://github.com/ACEsuit/mace-foundations) models |
 | `mace-omol-0-extra-large` | Pretrained MACE-OMOL-0 model |
+| `mace-les-off-small` | Pretrained [MACELES-OFF](https://github.com/ChengUCB/les_fit) model (requires [LES](https://github.com/ChengUCB/les) plugin) |
 | `mace` | Custom MACE models specified with the `modelPath` argument |
 
 When creating MACE models, the following keyword arguments to the `MLPotential` constructor are supported.

--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -57,7 +57,8 @@ class MACEPotentialImpl(MLPotentialImpl):
     >>> potential = MLPotential('mace-off23-small')
 
     Other available models include 'mace-off23-medium', 'mace-off23-large', 'mace-off24-medium',
-    'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium', and 'mace-omol-0-extra-large'.
+    'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium', 'mace-omol-0-extra-large',
+    and 'mace-les-off-small'.
 
     To use a locally trained MACE model, provide the path to the model file. For example:
 
@@ -112,7 +113,7 @@ class MACEPotentialImpl(MLPotentialImpl):
             The name of the MACE model.
             Options include 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large',
             'mace-off24-medium', 'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium',
-            'mace-omol-0-extra-large', and 'mace'.
+            'mace-omol-0-extra-large', 'mace-les-off-small', and 'mace'.
         modelPath : str, optional
             The path to the locally trained MACE model if ``name`` is 'mace'.
         """

--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -90,17 +90,17 @@ class MACEPotentialImpl(MLPotentialImpl):
         The path to the locally trained MACE model if ``name`` is 'mace'.
     """
 
-    # (Function name, model name, restrictive license, long-range)
+    # (Function name, model name, restrictive license name or None, long-range)
     KNOWN_MODELS = {
-        'mace-off23-small': ('mace_off', 'small', True, False),
-        'mace-off23-medium': ('mace_off', 'medium', True, False),
-        'mace-off23-large': ('mace_off', 'large', True, False),
-        'mace-off24-medium': ('mace_off', 'https://github.com/ACEsuit/mace-off/blob/main/mace_off24/MACE-OFF24_medium.model?raw=true', True, False),
-        'mace-mpa-0-medium': ('mace_mp', 'medium-mpa-0', False, False),
-        'mace-omat-0-small': ('mace_mp', 'small-omat-0', True, False),
-        'mace-omat-0-medium': ('mace_mp', 'medium-omat-0', True, False),
-        'mace-omol-0-extra-large': ('mace_omol', 'extra_large', True, False),
-        'mace-les-off-small': ('mace_off', 'https://github.com/ChengUCB/les_fit/blob/main/MACELES-OFF/MACELES-OFF_small_converted.model?raw=true', True, True),
+        'mace-off23-small': ('mace_off', 'small', 'ASL', False),
+        'mace-off23-medium': ('mace_off', 'medium', 'ASL', False),
+        'mace-off23-large': ('mace_off', 'large', 'ASL', False),
+        'mace-off24-medium': ('mace_off', 'https://github.com/ACEsuit/mace-off/blob/main/mace_off24/MACE-OFF24_medium.model?raw=true', 'ASL', False),
+        'mace-mpa-0-medium': ('mace_mp', 'medium-mpa-0', None, False),
+        'mace-omat-0-small': ('mace_mp', 'small-omat-0', 'ASL', False),
+        'mace-omat-0-medium': ('mace_mp', 'medium-omat-0', 'ASL', False),
+        'mace-omol-0-extra-large': ('mace_omol', 'extra_large', 'ASL', False),
+        'mace-les-off-small': ('mace_off', 'https://github.com/ChengUCB/les_fit/blob/main/MACELES-OFF/MACELES-OFF_small_converted.model?raw=true', 'CC BY-NC 4.0', True),
     }
 
     def __init__(self, name: str, modelPath) -> None:
@@ -172,11 +172,11 @@ class MACEPotentialImpl(MLPotentialImpl):
                 'mace_mp': mace_mp,
                 'mace_omol': mace_omol,
             }
-            fnName, name, warn, _ = MACEPotentialImpl.KNOWN_MODELS[self.name]
+            fnName, name, restrictiveLicense, _ = MACEPotentialImpl.KNOWN_MODELS[self.name]
             model = functions[fnName](model=name, device=device, return_raw_model=True).to(device)
-            if warn:
+            if restrictiveLicense is not None:
                 import logging
-                logging.warning(f'The model {self.name} is distributed under the restrictive ASL license.  Commercial use is not permitted.')
+                logging.warning(f'The model {self.name} is distributed under the restrictive {restrictiveLicense} license.  Commercial use is not permitted.')
         elif self.name == "mace":
             if self.modelPath is not None:
                 model = torch.load(self.modelPath, map_location=device).to(device)

--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -99,6 +99,7 @@ class MACEPotentialImpl(MLPotentialImpl):
         'mace-omat-0-small': ('mace_mp', 'small-omat-0', True, False),
         'mace-omat-0-medium': ('mace_mp', 'medium-omat-0', True, False),
         'mace-omol-0-extra-large': ('mace_omol', 'extra_large', True, False),
+        'mace-les-off-small': ('mace_off', 'https://github.com/ChengUCB/les_fit/blob/main/MACELES-OFF/MACELES-OFF_small_converted.model?raw=true', True, True),
     }
 
     def __init__(self, name: str, modelPath) -> None:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             'mace-omat-0-small = openmmml.models.macepotential:MACEPotentialImplFactory',
             'mace-omat-0-medium = openmmml.models.macepotential:MACEPotentialImplFactory',
             'mace-omol-0-extra-large = openmmml.models.macepotential:MACEPotentialImplFactory',
+            'mace-les-off-small = openmmml.models.macepotential:MACEPotentialImplFactory',
             'nequip = openmmml.models.nequippotential:NequIPPotentialImplFactory',
             'orb-v3-conservative-inf-omat = openmmml.models.orbpotential:OrbPotentialImplFactory',
             'orb-v3-conservative-omol = openmmml.models.orbpotential:OrbPotentialImplFactory',

--- a/test/TestMACEPotential.py
+++ b/test/TestMACEPotential.py
@@ -25,12 +25,15 @@ class TestMACE:
         'mace-mpa-0-medium': -8839.299589829867,
         'mace-omat-0-small': -8726.63865431241,
         'mace-omat-0-medium': -8679.026847088873,
-        'mace-omol-0-extra-large': -712903.4934289698
+        'mace-omol-0-extra-large': -712903.4934289698,
+        'mace-les-off-small': -713467.9354591698
     }
 
     @pytest.mark.parametrize("model", ['mace-off23-small', 'mace-off23-medium', 'mace-off23-large', 'mace-off24-medium',
-                                       'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium', 'mace-omol-0-extra-large'])
+                                       'mace-mpa-0-medium', 'mace-omat-0-small', 'mace-omat-0-medium', 'mace-omol-0-extra-large', 'mace-les-off-small'])
     def testCreatePureMLSystem(self, platform_int, model):
+        if 'mace-les' in model:
+            pytest.importorskip("les", reason="les is not installed")
         pdb = app.PDBFile(os.path.join(test_data_dir, "toluene", "toluene.pdb"))
         potential = MLPotential(model)
         system = potential.createSystem(pdb.topology, returnEnergyType='energy')

--- a/test/data/mace_energies.py
+++ b/test/data/mace_energies.py
@@ -24,13 +24,10 @@ atoms.calc = mace_omol('extra_large')
 results['mace-omol-0-extra-large'] = atoms.get_potential_energy()
 try:
     import les
-    has_les = True
-except ImportError:
-    print('No MACELES reference energies will be generated; you must first install LES from https://github.com/ChengUCB/les')
-    has_les = False
-if has_les:
     atoms.calc = mace_off('https://github.com/ChengUCB/les_fit/blob/main/MACELES-OFF/MACELES-OFF_small_converted.model?raw=true')
     results['mace-les-off-small'] = atoms.get_potential_energy()
+except ImportError:
+    print('No MACELES reference energies will be generated; you must first install LES from https://github.com/ChengUCB/les')
 atoms = ase.io.read('alanine-dipeptide/alanine-dipeptide-explicit.pdb')
 atoms.calc = mace_off('small')
 results['alanine-dipeptide'] = atoms.get_potential_energy()

--- a/test/data/mace_energies.py
+++ b/test/data/mace_energies.py
@@ -22,6 +22,15 @@ atoms.calc = mace_mp('medium-omat-0')
 results['mace-omat-0-medium'] = atoms.get_potential_energy()
 atoms.calc = mace_omol('extra_large')
 results['mace-omol-0-extra-large'] = atoms.get_potential_energy()
+try:
+    import les
+    has_les = True
+except ImportError:
+    print('No MACELES reference energies will be generated; you must first install LES from https://github.com/ChengUCB/les')
+    has_les = False
+if has_les:
+    atoms.calc = mace_off('https://github.com/ChengUCB/les_fit/blob/main/MACELES-OFF/MACELES-OFF_small_converted.model?raw=true')
+    results['mace-les-off-small'] = atoms.get_potential_energy()
 atoms = ase.io.read('alanine-dipeptide/alanine-dipeptide-explicit.pdb')
 atoms.calc = mace_off('small')
 results['alanine-dipeptide'] = atoms.get_potential_energy()


### PR DESCRIPTION
Adds MACELES-OFF as a pretrained MACE model.

Note that even though the MACE package now has support for MACELES, the LES package still has to be installed separately as a plugin.  Currently there is no release, so it is necessary to `pip install git+https://github.com/ChengUCB/les`.  We might therefore want to wait to see if there will be one per our usual policy with OpenMM-ML.

One other unclear point is the license, which is printed by the package as being ASL when the model is first downloaded but is listed [here](https://github.com/ChengUCB/les_fit) as CC BY-NC 4.0.  Both are restricted to non-commercial use, but we should make sure we're reporting the correct one.